### PR TITLE
Add SYN_DROPPED message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-**EVDEV event queue for Touchscreens on the Rasperry Pi**
+**EVDEV event queue for Touchscreens on the Raspberry Pi**
 
 # Features
 
-* Threaded message queue processing
-* Support for Adafruit capacitive screen
+* Threaded evdev message queue processing
+* Support for Adafruit Capacitive PiTFT displays
 
-# Features over original repository
+# New Changes
 
 * Support for SYN_DROPPED messages 
 
@@ -13,12 +13,14 @@
 
 The EVDEV library is stateful, so messages only include changes from previous state.  This means that at times only a ABS_X or ABS_Y (or sometimes neither) event will be queued on a move or a touch.   When only one is present, it means the previous value did not change.  If the event occurs at the exact same coordinate, neither will be present.   The application using the queue will need to keep this state in order to make sure messages occur at the correct coordinates.
 
+The SYN_DROPPED support added per guidance at https://www.freedesktop.org/software/libevdev/doc/1.1/syn_dropped.html
+
 # Usage
 ```
 @raspberrypi:~/pitft_touchscreen $ python3 example_usage.py 
 Input device /dev/input/touchscreen found
-Do whaterer you want to do while waiting for touchscreen events
-Do whaterer you want to do while waiting for touchscreen events
+Do whatever you want to do while waiting for touchscreen events
+Do whatever you want to do while waiting for touchscreen events
 Event received: {'touch': 1, 'id': 67, 'y': 215, 'time': 1533721688.999557, 'x': 102}
 Event received: {'touch': 1, 'id': 67, 'y': 213, 'time': 1533721689.030115, 'x': 102}
 Event received: {'touch': 1, 'id': 67, 'y': 211, 'time': 1533721689.054368, 'x': 102}
@@ -47,5 +49,5 @@ Event received: {'touch': 1, 'id': 68, 'y': 187, 'time': 1533721690.645795, 'x':
 Event received: {'touch': 1, 'id': 68, 'y': 185, 'time': 1533721690.657941, 'x': 107}
 Event received: {'touch': 1, 'id': 68, 'y': 183, 'time': 1533721690.682163, 'x': 107}
 Event received: {'touch': 0, 'id': -1, 'y': 107, 'time': 1533721690.791378, 'x': 107}
-Do whaterer you want to do while waiting for touchscreen events
+Do whatever you want to do while waiting for touchscreen events
 pi@raspberrypi:~/pitft_touchscreen $

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
-Very simple piTFT touchscreen handling class. Fully threaded ;-)
-Usage:
+**EVDEV event queue for Touchscreens on the Rasperry Pi**
+
+# Features
+
+* Threaded message queue processing
+* Support for Adafruit capacitive screen
+
+# Features over original repository
+
+* Support for SYN_DROPPED messages 
+
+# Notes
+
+The EVDEV library is stateful, so messages only include changes from previous state.  This means that at times only a ABS_X or ABS_Y (or sometimes neither) event will be queued on a move or a touch.   When only one is present, it means the previous value did not change.  If the event occurs at the exact same coordinate, neither will be present.   The application using the queue will need to keep this state in order to make sure messages occur at the correct coordinates.
+
+# Usage
 ```
 @raspberrypi:~/pitft_touchscreen $ python3 example_usage.py 
 Input device /dev/input/touchscreen found

--- a/pitft_touchscreen.py
+++ b/pitft_touchscreen.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 #  piTFT touchscreen handling using evdev
 
-import evdev
+
+try:
+    import evdev
+except ImportError:
+    print("Evdev package is not installed.  Run 'pip3 install evdev' or 'pip install evdev' (Python 2.7) to install.")
+    raise(ImportError("Evdev package not found."))
 import threading
 try:
     # python 3.5+

--- a/pitft_touchscreen.py
+++ b/pitft_touchscreen.py
@@ -46,7 +46,6 @@ class pitft_touchscreen(threading.Thread):
                 self.shutdown.set()
         # Loop for getting evdev events
         event = {'time': None, 'id': None, 'x': None, 'y': None, 'touch': None}
-        last_success_pos = {'x': None, 'y': None}
         dropping = False
         while not self.shutdown.is_set():
             for input_event in device.read_loop():
@@ -69,8 +68,8 @@ class pitft_touchscreen(threading.Thread):
                     event['touch'] = input_event.value
                 elif input_event.type == evdev.ecodes.SYN_REPORT:
                     if dropping:
-                        event['x'] = last_success_pos['x']
-                        event['y'] = last_success_pos['y']
+                        event['x'] = None
+                        event['y'] = None
                         event['touch'] = None
                         dropping = False
                     else:
@@ -78,7 +77,6 @@ class pitft_touchscreen(threading.Thread):
                         self.events.put(event)
                         e = event
                         event = {'x': e['x'], 'y': e['y']}
-                        last_success_pos = {'x': e['x'], 'y': e['y']}
                         try:
                             event['id'] = e['id']
                         except KeyError:

--- a/pitft_touchscreen.py
+++ b/pitft_touchscreen.py
@@ -46,6 +46,8 @@ class pitft_touchscreen(threading.Thread):
                 self.shutdown.set()
         # Loop for getting evdev events
         event = {'time': None, 'id': None, 'x': None, 'y': None, 'touch': None}
+        last_success_pos = {'x': None, 'y': None}
+        dropping = False
         while not self.shutdown.is_set():
             for input_event in device.read_loop():
                 if input_event.type == evdev.ecodes.EV_ABS:
@@ -66,18 +68,27 @@ class pitft_touchscreen(threading.Thread):
                 elif input_event.type == evdev.ecodes.EV_KEY:
                     event['touch'] = input_event.value
                 elif input_event.type == evdev.ecodes.SYN_REPORT:
-                    event['time'] = input_event.timestamp()
-                    self.events.put(event)
-                    e = event
-                    event = {'x': e['x'], 'y': e['y']}
-                    try:
-                        event['id'] = e['id']
-                    except KeyError:
-                        event['id'] = None
-                    try:
-                        event['touch'] = e['touch']
-                    except KeyError:
+                    if dropping:
+                        event['x'] = last_success_pos['x']
+                        event['y'] = last_success_pos['y']
                         event['touch'] = None
+                        dropping = False
+                    else:
+                        event['time'] = input_event.timestamp()
+                        self.events.put(event)
+                        e = event
+                        event = {'x': e['x'], 'y': e['y']}
+                        last_success_pos = {'x': e['x'], 'y': e['y']}
+                        try:
+                            event['id'] = e['id']
+                        except KeyError:
+                            event['id'] = None
+                        try:
+                            event['touch'] = e['touch']
+                        except KeyError:
+                            event['touch'] = None
+                elif input_event.type == evdev.ecodes.SYN_DROPPED:
+                    dropping = True
         if self.grab:
             device.ungrab()
 


### PR DESCRIPTION
This PR contains the changes necessary to support SYN_DROPPED messages from EVDEV as explained here: https://www.freedesktop.org/software/libevdev/doc/1.1/syn_dropped.html.

Support is fairly simple when only single-touch screens such as the Adafruit 2.8 Capacitive PiTFT.  Multi-touch support (if added to support screens such as the Pimoroni HyperPixel) will require the handling of ABS_MT_SLOT in the code.